### PR TITLE
Openssl0.10.12

### DIFF
--- a/libindy-crypto/Cargo.toml
+++ b/libindy-crypto/Cargo.toml
@@ -26,7 +26,7 @@ sha2 = "0.7.1"
 sha3 = "0.7.3"
 time = "0.1.36"
 env_logger = "0.5.10"
-openssl = { version = "0.9.21", optional = true }
+openssl = { version = "0.10.12", optional = true }
 serde = { version = "1.0",  optional = true}
 serde_json = { version = "1.0",  optional = true}
 serde_derive = { version = "1.0",  optional = true}

--- a/libindy-crypto/src/bn/openssl.rs
+++ b/libindy-crypto/src/bn/openssl.rs
@@ -2,8 +2,8 @@ use errors::IndyCryptoError;
 
 use int_traits::IntTraits;
 
-use openssl::bn::{BigNum, BigNumRef, BigNumContext, MSB_MAYBE_ZERO};
-use openssl::hash::{hash2, MessageDigest, Hasher};
+use openssl::bn::{BigNum, BigNumRef, BigNumContext, MsbOption};
+use openssl::hash::{hash, MessageDigest, Hasher};
 use openssl::error::ErrorStack;
 
 #[cfg(feature = "serialization")]
@@ -109,7 +109,7 @@ impl BigNumber {
 
     pub fn rand(size: usize) -> Result<BigNumber, IndyCryptoError> {
         let mut bn = BigNumber::new()?;
-        BigNumRef::rand(&mut bn.openssl_bn, size as i32, MSB_MAYBE_ZERO, false)?;
+        BigNumRef::rand(&mut bn.openssl_bn, size as i32, MsbOption::MAYBE_ZERO, false)?;
         Ok(bn)
     }
 
@@ -175,7 +175,7 @@ impl BigNumber {
     }
 
     pub fn hash(data: &[u8]) -> Result<Vec<u8>, IndyCryptoError> {
-        Ok(hash2(MessageDigest::sha256(), data)?.to_vec())
+        Ok(hash(MessageDigest::sha256(), data)?.to_vec())
     }
 
     pub fn add(&self, a: &BigNumber) -> Result<BigNumber, IndyCryptoError> {
@@ -414,7 +414,7 @@ impl BigNumber {
             sha256.update(&num)?;
         }
 
-        Ok(sha256.finish2()?.to_vec())
+        Ok(sha256.finish()?.to_vec())
     }
 }
 

--- a/libindy-crypto/src/cl/constants.rs
+++ b/libindy-crypto/src/cl/constants.rs
@@ -19,7 +19,7 @@ pub const ITERATION: usize = 4;
   Dmitry Khovratovich, suggests to use same size as LARGE_MVECT
   FIXME sync the paper and remove this comment
 */
-pub const LARGE_NONCE: usize = 80;
+pub const LARGE_NONCE: usize = 80; // number of bits
 pub const LARGE_ALPHATILDE: usize = 2787;
 
 // Constants that are used throughout the CL signatures code, so avoiding recomputation.


### PR DESCRIPTION
bumped rust openssl version to 0.10.12 which used openssl 1.1.1 which support ed25519, tls1.3 and has better Android support