### PR TITLE
Upgrade to openssl v0.10

### DIFF
--- a/libindy-crypto/Cargo.toml
+++ b/libindy-crypto/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT/Apache-2.0"
 [lib]
 name = "indy_crypto"
 path = "src/lib.rs"
-crate-type = ["staticlib","rlib", "dylib"]
+crate-type = ["staticlib", "rlib", "dylib"]
 
 [features]
 default = ["bn_openssl", "pair_amcl", "serialization"]
@@ -26,7 +26,7 @@ sha2 = "0.7.1"
 sha3 = "0.7.3"
 time = "0.1.36"
 env_logger = "0.5.10"
-openssl = { version = "0.9.21", optional = true }
+openssl = { version = "0.10.12", optional = true }
 serde = { version = "1.0",  optional = true}
 serde_json = { version = "1.0",  optional = true}
 serde_derive = { version = "1.0",  optional = true}

--- a/libindy-crypto/src/bn/openssl.rs
+++ b/libindy-crypto/src/bn/openssl.rs
@@ -2,8 +2,8 @@ use errors::IndyCryptoError;
 
 use int_traits::IntTraits;
 
-use openssl::bn::{BigNum, BigNumRef, BigNumContext, MSB_MAYBE_ZERO};
-use openssl::hash::{hash2, MessageDigest, Hasher};
+use openssl::bn::{BigNum, BigNumRef, BigNumContext, MsbOption};
+use openssl::hash::{hash, MessageDigest, Hasher};
 use openssl::error::ErrorStack;
 
 #[cfg(feature = "serialization")]
@@ -109,7 +109,7 @@ impl BigNumber {
 
     pub fn rand(size: usize) -> Result<BigNumber, IndyCryptoError> {
         let mut bn = BigNumber::new()?;
-        BigNumRef::rand(&mut bn.openssl_bn, size as i32, MSB_MAYBE_ZERO, false)?;
+        BigNumRef::rand(&mut bn.openssl_bn, size as i32, MsbOption::MAYBE_ZERO, false)?;
         Ok(bn)
     }
 
@@ -175,7 +175,7 @@ impl BigNumber {
     }
 
     pub fn hash(data: &[u8]) -> Result<Vec<u8>, IndyCryptoError> {
-        Ok(hash2(MessageDigest::sha256(), data)?.to_vec())
+        Ok(hash(MessageDigest::sha256(), data)?.to_vec())
     }
 
     pub fn add(&self, a: &BigNumber) -> Result<BigNumber, IndyCryptoError> {
@@ -414,7 +414,7 @@ impl BigNumber {
             sha256.update(&num)?;
         }
 
-        Ok(sha256.finish2()?.to_vec())
+        Ok(sha256.finish()?.to_vec())
     }
 }
 


### PR DESCRIPTION
Upgrade the openssl dependency to v0.10. I had to do this as otherwise I couldn't build libindy-crypto on OS X. Before this patch, the build would fail like this:

```
$ rustc --version
rustc 1.29.0 (aa3ca1994 2018-09-11)
$ cargo build
   Compiling openssl v0.9.24
error: failed to run custom build command for `openssl v0.9.24`
process didn't exit successfully: `/Users/arve/Projects/indy-crypto/libindy-crypto/target/debug/build/openssl-de72db301f305406/build-script-build` (exit code: 101)
--- stderr
thread 'main' panicked at 'Unable to detect OpenSSL version', /Users/arve/.cargo/registry/src/github.com-1ecc6299db9ec823/openssl-0.9.24/build.rs:16:14
```