### PR TITLE
Fix links and align version in package.json

### DIFF
--- a/wrappers/javascript/package.json
+++ b/wrappers/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "indycrypto",
-  "version": "0.0.1",
+  "version": "0.4.3",
   "description": "Shared crypto library for Hyperledger Indy components.",
   "main": "index.js",
   "scripts": {
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/aknuds1/indy-crypto.git"
+    "url": "git+https://github.com/hyperledger/indy-crypto.git"
   },
   "keywords": [
     "crypto",
@@ -18,9 +18,9 @@
   "author": "Hyperledger Indy team",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/aknuds1/indy-crypto/issues"
+    "url": "https://github.com/hyperledger/indy-crypto/issues"
   },
-  "homepage": "https://github.com/aknuds1/indy-crypto#readme",
+  "homepage": "https://github.com/hyperledger/indy-crypto#readme",
   "devDependencies": {
     "ava": "^1.0.0-rc.1",
     "ramda": "^0.25.0"


### PR DESCRIPTION
Fix links in wrappers/javascript/package.json to be to the official repository instead of mine, and align version with that of the core library.